### PR TITLE
Show how to use a custom locator to generate Gralde metadata for system libraries

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -9,4 +9,5 @@ repositories {
 
 dependencies {
     implementation platform("dev.nokee:nokee-gradle-plugins:0.5.0-43daa054")
+    implementation 'commons-io:commons-io:2.6'
 }

--- a/buildSrc/src/main/groovy/OpenSslLocator.groovy
+++ b/buildSrc/src/main/groovy/OpenSslLocator.groovy
@@ -1,0 +1,185 @@
+import groovy.transform.CompileStatic
+import org.apache.commons.io.FilenameUtils
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
+
+import java.util.concurrent.Callable
+import java.util.regex.Pattern
+
+/**
+ * This locator is just an example on how Nokee intend to solve the discovery of system libraries, toolchains, Conan dependencies, Nuget dependencies, etc.
+ * Nokee will provide a configuration hook in settings.gradle allowing users to add new locators and possibly mutation of the discovered components.
+ * Upon execution, the locator will find the interesting bit of information and publish modeling elements for them.
+ * In this example, the modeling elements are straight Gradle module metadata but that will be abstracted by Nokee.
+ *
+ * Nokee will generate a cache of all the model element.
+ * In this example, we generate a cache per-subproject but it should really be single cache for the entire project.
+ */
+final class OpenSslLocator implements Callable<String> {
+    private final String group = 'system.OpenSSL'
+    private String versionCache = null
+    private final Provider<Directory> cachingDirectory
+
+    OpenSslLocator(Provider<Directory> cachingDirectory) {
+        this.cachingDirectory = cachingDirectory
+    }
+
+    private File repositoryFile(String path) {
+        def result = cachingDirectory.get().file("${group.replace('.', '/')}/${path}").asFile
+        result.parentFile.mkdirs()
+        result.createNewFile()
+        return result
+    }
+
+    void buildCacheIfAbsent() {
+        if (versionCache != null) {
+            return;
+        }
+
+        module("libcrypto") {
+            [ """{
+                "name": "apiShared",
+                "attributes": ${cppApiAttributes},
+                "files": [${file('include')}]
+            }""",
+            """{
+                "name": "linkShared",
+                "attributes": ${nativeLinkAttributes},
+                "files": [${file('lib/libcrypto.lib')}]
+            }""",
+            """{
+                "name": "runtimeShared",
+                "attributes": ${nativeRuntimeAttributes},
+                "files": [${file('bin/libcrypto-1_1.dll')}]
+            }"""]
+        }
+
+        module("libssl") {
+            [ """{
+                "name": "apiShared",
+                "attributes": ${cppApiAttributes},
+                "files": [${file('include')}]
+            }""",
+              """{
+                "name": "linkShared",
+                "attributes": ${nativeLinkAttributes},
+                "files": [${file('lib/libssl.lib')}]
+            }""",
+              """{
+                "name": "runtimeShared",
+                "attributes": ${nativeRuntimeAttributes},
+                "files": [${file('bin/libssl-1_1.dll')}]
+            }"""]
+        }
+    }
+
+    private void module(String name, @DelegatesTo(value = ModuleSpec, strategy = Closure.DELEGATE_FIRST) Closure<List<String>> closure) {
+        def moduleSpec = new ModuleSpec(name)
+        closure.delegate = moduleSpec
+        closure.resolveStrategy = Closure.DELEGATE_FIRST
+        repositoryFile("${name}/${version}/${name}-${version}.module").text = """{
+            |    "formatVersion": "1.0",
+            |    "component": {
+            |        "group": "${group}",
+            |        "module": "${name}",
+            |        "version": "${version}"
+            |    },
+            |    "createdBy": {
+            |        "gradle": {
+            |            "version": "4.3",
+            |            "buildId": "abc123"
+            |        }
+            |    },
+            |    "variants": [
+            |       ${closure.call(moduleSpec).join(', ')}
+            |    ]
+            |}
+            |""".stripMargin()
+    }
+
+    private File getOpenSslLocation() {
+        if (System.getenv().containsKey('LIB_OPENSSL_X86')) {
+            return new File(System.getenv('LIB_OPENSSL_X86'))
+        }
+        return new File('C:\\Program Files (x86)\\OpenSSL-Win32')
+    }
+
+    private String getVersion() {
+        if (versionCache == null) {
+            def versionPattern = Pattern.compile('\\d+\\.\\d+\\.\\d+[a-z]?')
+            def matches = versionPattern.matcher(new File(getOpenSslLocation(), 'changes.txt').text)
+            if (matches.find() && matches.find()) {
+                versionCache = matches.group()
+            } else {
+                // TODO: Do not throw exception, instead don't generate cache
+                throw new IllegalStateException("Could not find version")
+            }
+        }
+
+        return versionCache
+    }
+
+    private File targetFile(String path) {
+        def result = new File(getOpenSslLocation(), path)
+        assert result.exists()
+        return result
+    }
+
+    @Override
+    String call() throws Exception {
+        buildCacheIfAbsent()
+        return cachingDirectory.get().asFile.absolutePath
+    }
+
+    private final class ModuleSpec {
+        final String name;
+        ModuleSpec(String moduleName) {
+            this.name = moduleName
+        }
+
+        String relativize(String path) {
+            def pathBackToRoot = []
+            def n = repositoryFile("${name}/${version}").absolutePath.split('\\\\').length
+            n.times {
+                pathBackToRoot << '..'
+            }
+            return pathBackToRoot.join('/') + '/' + targetFile(path).absolutePath.replace('\\', '/')
+        }
+
+        String file(String path) {
+            return """{ 
+                    "name": "${FilenameUtils.getName(path)}",
+                    "url": "${relativize(path)}",
+                    "size": "TODO",
+                    "sha1": "TODO",
+                    "md5": "TODO"
+                }"""
+        }
+
+        String getCppApiAttributes() {
+            return """{
+                    "org.gradle.usage": "cplusplus-api"
+                }"""
+        }
+
+        String getNativeRuntimeAttributes() {
+            return """{
+                    "org.gradle.usage": "native-runtime",
+                    "org.gradle.native.operatingSystem": "windows",
+                    "org.gradle.native.architecture": "x86",
+                    "dev.nokee.buildType": "release",
+                    "dev.nokee.linkage": "shared"
+                }"""
+        }
+
+        String getNativeLinkAttributes() {
+            return """{
+                    "org.gradle.usage": "native-link",
+                    "org.gradle.native.operatingSystem": "windows",
+                    "org.gradle.native.architecture": "x86",
+                    "dev.nokee.buildType": "release",
+                    "dev.nokee.linkage": "shared"
+                }"""
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/RepositoryUtils.groovy
+++ b/buildSrc/src/main/groovy/RepositoryUtils.groovy
@@ -1,0 +1,21 @@
+import groovy.transform.CompileStatic
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+
+@CompileStatic
+final class RepositoryUtils {
+    private RepositoryUtils() {}
+
+    static Action<MavenArtifactRepository> systemOpenSsl(Project project) {
+        return new Action<MavenArtifactRepository>() {
+            @Override
+            void execute(MavenArtifactRepository repo) {
+                repo.url = new OpenSslLocator(project.layout.buildDirectory.dir('repository-cache'))
+                repo.metadataSources {
+                    it.gradleMetadata()
+                }
+            }
+        }
+    }
+}

--- a/static_lib/static_lib.gradle
+++ b/static_lib/static_lib.gradle
@@ -1,11 +1,16 @@
 import dev.nokee.language.cpp.CppHeaderSet
 import dev.nokee.language.c.CHeaderSet
 import static ConfigurationUtils.withDefaultLibraryConfiguration
+import static RepositoryUtils.systemOpenSsl
 
 plugins {
     id 'dev.nokee.native-library'
     id 'dev.nokee.cpp-language'
     id 'dev.nokee.c-language'
+}
+
+repositories {
+    maven(systemOpenSsl(project))
 }
 
 library(withDefaultLibraryConfiguration())
@@ -18,6 +23,11 @@ library { lib->
         c { from(fileTree(dir: '.', include: '*.c')) }
         configureEach(CppHeaderSet) { from(projectDir) }
         configureEach(CHeaderSet) { from(projectDir) }
+    }
+
+    dependencies {
+        implementation 'system.OpenSSL:libcrypto:1.1.1h'
+        implementation 'system.OpenSSL:libssl:1.1.1h'
     }
 
     // TODO-KFH temp change to try to figure out what is bringing in DriverSpec.h

--- a/subsystem_a/util_1/util_1.gradle
+++ b/subsystem_a/util_1/util_1.gradle
@@ -8,6 +8,10 @@ plugins {
     id 'code-sign'
 }
 
+repositories {
+    maven(RepositoryUtils.systemOpenSsl(project))
+}
+
 import dev.nokee.language.c.CHeaderSet
 import dev.nokee.language.cpp.CppHeaderSet
 

--- a/subsystem_b/server_1/server_1.gradle
+++ b/subsystem_b/server_1/server_1.gradle
@@ -6,6 +6,10 @@ plugins {
     id 'code-sign'
 }
 
+repositories {
+    maven(RepositoryUtils.systemOpenSsl(project))
+}
+
 application(withDefaultApplicationConfiguration())
 application { app->
 


### PR DESCRIPTION
This PR is an example of how Nokee intends to solve the system libraries' discovery and consumption. The idea is to generate the Gradle metadata locally to allow Gradle to perform a normal dependency resolution. It's the most flexible and powerful. With this solution, we can use dependency locking, version conflict resolution, attribute matching, etc.