### PR TITLE
Broken add vs linker option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
 allprojects {
     apply plugin: 'lifecycle-debug'
     apply plugin: 'lifecycle-release'
+    apply plugin: 'default-import'
     apply plugin: 'dev.nokee.visual-studio-ide'
 
     pluginManager.withPlugin('code-sign') {

--- a/buildSrc/src/main/groovy/default-import.gradle
+++ b/buildSrc/src/main/groovy/default-import.gradle
@@ -1,0 +1,6 @@
+ext {
+    addVSLinkerOption = ConfigurationUtils.&addVSLinkerOption
+    addVSCompilerOption = ConfigurationUtils.&addVSCompilerOption
+    withDefaultLibraryConfiguration = ConfigurationUtils.&withDefaultLibraryConfiguration
+    withDefaultApplicationConfiguration = ConfigurationUtils.&withDefaultApplicationConfiguration
+}

--- a/static_lib/static_lib.gradle
+++ b/static_lib/static_lib.gradle
@@ -1,6 +1,5 @@
 import dev.nokee.language.cpp.CppHeaderSet
 import dev.nokee.language.c.CHeaderSet
-import static ConfigurationUtils.withDefaultLibraryConfiguration
 //import static RepositoryUtils.systemOpenSsl
 
 plugins {

--- a/static_lib/static_lib.gradle
+++ b/static_lib/static_lib.gradle
@@ -1,7 +1,7 @@
 import dev.nokee.language.cpp.CppHeaderSet
 import dev.nokee.language.c.CHeaderSet
 import static ConfigurationUtils.withDefaultLibraryConfiguration
-import static RepositoryUtils.systemOpenSsl
+//import static RepositoryUtils.systemOpenSsl
 
 plugins {
     id 'dev.nokee.native-library'
@@ -9,9 +9,9 @@ plugins {
     id 'dev.nokee.c-language'
 }
 
-repositories {
-    maven(systemOpenSsl(project))
-}
+// repositories {
+//     maven(systemOpenSsl(project))
+// }
 
 library(withDefaultLibraryConfiguration())
 //library(withOpenSSLLibraryConfiguration())
@@ -25,10 +25,10 @@ library { lib->
         configureEach(CHeaderSet) { from(projectDir) }
     }
 
-    dependencies {
-        implementation 'system.OpenSSL:libcrypto:1.1.1h'
-        implementation 'system.OpenSSL:libssl:1.1.1h'
-    }
+    // dependencies {
+    //     implementation 'system.OpenSSL:libcrypto:1.1.1h'
+    //     implementation 'system.OpenSSL:libssl:1.1.1h'
+    // }
 
     // TODO-KFH temp change to try to figure out what is bringing in DriverSpec.h
     // TODO(nokeedev): Figuring out where a header comes from should be made easy with Nokee by exposing the data it already acquire during compilation

--- a/subsystem_a/util_1/util_1.gradle
+++ b/subsystem_a/util_1/util_1.gradle
@@ -31,6 +31,8 @@ application { app->
         configureEach(CHeaderSet) { from(projectDir) }
     }
 
+    addVSLinkerOption("/subsystem:windows").call(app)
+
     dependencies {
         implementation project(':static_lib')
     }

--- a/subsystem_a/util_1/util_1.gradle
+++ b/subsystem_a/util_1/util_1.gradle
@@ -1,5 +1,3 @@
-import static ConfigurationUtils.withDefaultApplicationConfiguration
-
 plugins {
     id 'legacy-installable'
     id 'dev.nokee.native-application'

--- a/subsystem_b/server_1/server_1.gradle
+++ b/subsystem_b/server_1/server_1.gradle
@@ -1,5 +1,3 @@
-import static ConfigurationUtils.withDefaultApplicationConfiguration
-
 plugins {
     id 'dev.nokee.cpp-application'
     id 'legacy-installable'


### PR DESCRIPTION
Here is one way to import the functions by default in all projects. This can avoid the cryptic issue we saw.